### PR TITLE
added first_name last_name and profile_picture to users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,8 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name, :profile_picture])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:first_name, :last_name, :profile_picture])
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,8 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  validates :first_name, presence: true, length: { maximum: 50 }
+  validates :last_name, presence: true, length: { maximum: 50 }
+  validates :profile_picture, presence: true
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,4 +73,9 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  # manually updated action mailer
+  # will need to be changed when in production!!
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
 end

--- a/db/migrate/20240604103347_add_details_to_users.rb
+++ b/db/migrate/20240604103347_add_details_to_users.rb
@@ -1,0 +1,7 @@
+class AddDetailsToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :first_name, :string
+    add_column :users, :last_name, :string
+    add_column :users, :profile_picture, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_03_160152) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_04_103347) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -57,6 +57,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_03_160152) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "first_name"
+    t.string "last_name"
+    t.string "profile_picture"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
added migration file to update first_name, last_name and profile_picture in the users table.
updated the validations for first_name, last_name and profile_picture:
 - presence is required
 - first_name and last_name need to be no longer than 50 characters
require first_name, last_name and profile_picture for account creation and account updating. 